### PR TITLE
s3cmd replace all aws perl scripts

### DIFF
--- a/libexec/erlang
+++ b/libexec/erlang
@@ -357,24 +357,12 @@ copy_release_to_release_store() {
   fi
   status "Copying release ${RELEASE_VERSION} to $RELEASE_STORE_TYPE release store"
   if [ "$RELEASE_STORE_TYPE" = "s3" ]; then
-    local _aws_script_content=$(cat $BASE_PATH/libexec/aws)
     __sync_remote "
       [ -f $PROFILE ] && source $PROFILE
       set -e
       cd $(dirname ${_release_file}) $SILENCE
-      AWS_ARGUMENTS=\"put ${AWS_BUCKET_NAME}/${APP}_${RELEASE_VERSION}${_release_revision}.${_release_type}.tar.gz $(basename ${_release_file})\" AWS_ACCESS_KEY_ID=\"$AWS_ACCESS_KEY_ID\" AWS_SECRET_ACCESS_KEY=\"$AWS_SECRET_ACCESS_KEY\" perl $SILENCE <<'EOF'
-${_aws_script_content}
-EOF
-" "$HOSTS_APP_USER" "
-
-      [ -f $PROFILE ] && source $PROFILE
-      set -e
-      cd $(dirname ${_release_file}) $SILENCE
-      AWS_ARGUMENTS=\"put ${AWS_BUCKET_NAME}/${APP}_${RELEASE_VERSION}${_release_revision}.${_release_type}.tar.gz $(basename ${_release_file})\" AWS_ACCESS_KEY_ID=\"$AWS_ACCESS_KEY_ID\" \\
-      AWS_SECRET_ACCESS_KEY=\"$AWS_SECRET_ACCESS_KEY\" perl $SILENCE <<'EOF'
-        content from libexec/aws file
-EOF
-"
+      s3cmd --access_key "$AWS_ACCESS_KEY_ID" --secret_key "$AWS_SECRET_ACCESS_KEY" put $(basename ${_release_file}) s3://${AWS_BUCKET_NAME}/${APP}_${RELEASE_VERSION}${_release_revision}.${_release_type}.tar.gz
+      "
     [ "$DOCKER_PUSH" = "true" ] && hint_message "Ignoring --push flag because s3 release store is not a docker registry." || :
   elif [ "$RELEASE_STORE_TYPE" = "local" ]; then
     status "Copying $(basename $_release_file) to release store"
@@ -546,7 +534,7 @@ upload_file_to_s3_release_store() {
     [[ $REPLY = [yY] ]] || exit 1
   }
   status "Uploading file $_source_file to $_destination_file"
-  AWS_ARGUMENTS="put ${AWS_BUCKET_NAME}/${_destination_file} ${_source_file}" AWS_ACCESS_KEY_ID="$AWS_ACCESS_KEY_ID" AWS_SECRET_ACCESS_KEY="$AWS_SECRET_ACCESS_KEY" perl $BASE_PATH/libexec/aws || {
+  s3cmd --access_key "$AWS_ACCESS_KEY_ID" --secret_key "$AWS_SECRET_ACCESS_KEY" "put ${_source_file} s3://${AWS_BUCKET_NAME}/${_destination_file}" || {
       error "\nFAILED to upload $_source_file\n"
   }
 }
@@ -602,7 +590,7 @@ download_file_from_s3_release_store() {
     exit 2
   }
   status "Downloading $_source_file to $_destination_file"
-  AWS_ARGUMENTS="get ${AWS_BUCKET_NAME}/${_source_file}" AWS_ACCESS_KEY_ID="$AWS_ACCESS_KEY_ID" AWS_SECRET_ACCESS_KEY="$AWS_SECRET_ACCESS_KEY" perl $BASE_PATH/libexec/aws 2>/dev/null > "$_destination_file" || {
+  s3cmd --access_key "$AWS_ACCESS_KEY_ID" --secret_key "$AWS_SECRET_ACCESS_KEY" "get ${AWS_BUCKET_NAME}/${_source_file}" "$_destination_file" || {
       [[ -f "$_destination_file" ]] && [[ ! -s "$_destination_file" ]] && rm "$_destination_file"
       error "\nFAILED to download $_source_file\n"
   }
@@ -766,7 +754,7 @@ __get_releases_in_store() {
   local _release_type="$1"
   __detect_release_store_type
   if [ "$RELEASE_STORE_TYPE" = "s3" ]; then
-    AWS_ACCESS_KEY_ID="$AWS_ACCESS_KEY_ID" AWS_SECRET_ACCESS_KEY="$AWS_SECRET_ACCESS_KEY" ${BASE_PATH}/libexec/aws ls ${AWS_BUCKET_NAME} 2>/dev/null | grep -o "${APP}_.*.${_release_type}.tar.gz" | sort -bt. -k1,1 -k2,2n -k3,3n -k4,4n -k5,5n
+    s3cmd --access_key "$AWS_ACCESS_KEY_ID" --secret_key "$AWS_SECRET_ACCESS_KEY" "ls s3://${AWS_BUCKET_NAME}" 2>/dev/null | grep -o "${APP}_.*.${_release_type}.tar.gz" | sort -bt. -k1,1 -k2,2n -k3,3n -k4,4n -k5,5n
   elif [ "$RELEASE_STORE_TYPE" = "local" ]; then
     local _release_file;
     for _release_file in $(ls -1 ${RELEASE_STORE}/releases/${APP}_*.${_release_type}.tar.gz | sort -bt. -k1,1 -k2,2n -k3,3n -k4,4n -k5,5n); do
@@ -802,26 +790,13 @@ upload_release_archive() {
   # when building releases with mix, the tar does not contain the app name as subdirectory
   [[ "$RELEASE_CMD" = "mix" ]] && [[ ! "$_release_file" =~ upgrade\.tar\.gz$ ]] && _destination_directory="${_destination_directory%%/}/${APP}"
   if [ "$RELEASE_STORE_TYPE" = "s3" ]; then
-    local _aws_script_content=$(cat $BASE_PATH/libexec/aws)
     __remote "
       [ -f $PROFILE ] && source $PROFILE
       set -e
       mkdir -p ${_destination_directory} $SILENCE
       cd ${_destination_directory} $SILENCE
-      AWS_ARGUMENTS=\"get ${AWS_BUCKET_NAME}/${_release_file} \" AWS_ACCESS_KEY_ID=\"$AWS_ACCESS_KEY_ID\" AWS_SECRET_ACCESS_KEY=\"$AWS_SECRET_ACCESS_KEY\" perl > ${APP}_${_release_version}.tar.gz 2>/dev/null <<'EOF'
-${_aws_script_content}
-EOF
-" "$HOSTS_APP_USER" "
-
-      [ -f $PROFILE ] && source $PROFILE
-      set -e
-      mkdir -p ${_destination_directory} $SILENCE
-      cd ${_destination_directory} $SILENCE
-      AWS_ARGUMENTS=\"get ${AWS_BUCKET_NAME}/${_release_file} \" AWS_ACCESS_KEY_ID=\"$AWS_ACCESS_KEY_ID\" \\
-      AWS_SECRET_ACCESS_KEY=\"$AWS_SECRET_ACCESS_KEY\" perl > ${APP}_${_release_version}.tar.gz 2>/dev/null <<'EOF'
-        content from libexec/aws file
-EOF
-"
+      s3cmd --access_key ${AWS_ACCESS_KEY_ID} --secret_key ${AWS_SECRET_ACCESS_KEY} get s3://${AWS_BUCKET_NAME}/${_release_file} ${APP}_${_release_version}.tar.gz
+      "
   elif [ "$RELEASE_STORE_TYPE" = "local" ]; then
     __remote "
       [ -f $PROFILE ] && source $PROFILE


### PR DESCRIPTION
## Jira Ticket
https://ovice.atlassian.net/browse/SRE-594

## Overview
* `s3cmd` replace all aws perl scripts 

## Areas to focus on
* the original script doesn't support Signature Version 2 authentication so it cannot access to eu-central-1 region bucket.
* so we replace it with `s3cmd` command.
* the codes are coming from https://github.com/edeliver/edeliver/compare/master...joskar:s3cmd